### PR TITLE
Added method for receiving multiple bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To integrate Socket.swift into your Xcode project using CocoaPods, specify it in
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
 target '<Your Target Name>' do
-    pod 'Socket.swift' ~> '2.0'
+    pod 'Socket.swift', '~> 2.0'
 end
 ```
 

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -38,7 +38,15 @@ open class Socket {
         }
         return byte
     }
-    
+
+    open func read(_ buffer: inout [Byte], bufferSize: Int) throws -> Int {
+        let received = OS.recv(fileDescriptor, &buffer, bufferSize, 0)
+        if received == -1 {
+            throw Error(errno: errno)
+        }
+        return received
+    }
+
     open func write(_ buffer: UnsafeRawPointer, length: Int) throws {
         var totalWritten = 0
         while totalWritten < length {

--- a/Tests/SocketSwiftTests/SocketSwiftTests.swift
+++ b/Tests/SocketSwiftTests/SocketSwiftTests.swift
@@ -31,6 +31,30 @@ class SocketSwiftTests: XCTestCase {
         
         XCTAssertEqual(readBytes, bytes)
         client.close()
+        server.close()
+    }
+
+    func testReceivingMultipleBytes() {
+        let server = try! Socket.tcpListening(port: 8090)
+
+        let client = try! Socket(.inet)
+        try! client.connect(port: 8090)
+
+        let bytes = "Hello World".bytes
+        let writableClient = try! server.accept();
+        try! writableClient.write(bytes, length: bytes.count)
+        writableClient.close()
+
+        var buffer = [Byte](repeating: 0, count: 16)
+        let totalBytesReceived = try! client.read(&buffer, bufferSize: 16)
+
+        let results = Array(buffer.prefix(totalBytesReceived))
+
+        XCTAssertEqual(totalBytesReceived, 11)
+        XCTAssertEqual(results, bytes)
+
+        client.close();
+        server.close()
     }
     
     func testError() {
@@ -45,8 +69,9 @@ class SocketSwiftTests: XCTestCase {
     
     static var allTests = [
         ("testExample", testExample),
-        ("testError", testError)
-        ]
+        ("testError", testError),
+        ("testReceivingMultipleBytes", testReceivingMultipleBytes)
+    ]
 }
 
 private extension String {


### PR DESCRIPTION
I'm working on a server software that needs to receive large files pushed by clients. Receiving 1 byte at a time adds too much overhead resulting in lengthy uploads. By reading multiple bytes per `recv` call I was able to speed up transfers by many orders of magnitude.