### PR TITLE
Fix deprecation warning

### DIFF
--- a/Sources/TLS.swift
+++ b/Sources/TLS.swift
@@ -51,7 +51,7 @@ open class TLS {
             SSLSetIOFuncs(context, sslRead, sslWrite)
             SSLSetConnection(context, &self.fd)
             if let peerName = config.peer {
-                SSLSetPeerDomainName(context, peerName, peerName.characters.count)
+                SSLSetPeerDomainName(context, peerName, peerName.count)
             }
             
             var status: OSStatus = -1


### PR DESCRIPTION
The character view has been deprecated in Swift 4.

https://developer.apple.com/documentation/swift/string/1540072-characters

